### PR TITLE
feat: add Daily Focus feature - auto-select today's tasks

### DIFF
--- a/app/backlog/page.tsx
+++ b/app/backlog/page.tsx
@@ -13,6 +13,7 @@ import {
   type TaskStatus,
   type TaskType,
 } from "../../lib/types";
+import { FocusPanel } from "../components/focus-panel";
 import { LoadingButton } from "../components/loading-button";
 import { type AiSuggestionConfig, TaskCard } from "../components/task-card";
 import { useWorkspaceId } from "../components/use-workspace-id";
@@ -687,6 +688,8 @@ export default function BacklogPage() {
           </div>
         </div>
       </header>
+
+      <FocusPanel />
 
       {items.filter(
         (item) =>

--- a/app/components/focus-panel.tsx
+++ b/app/components/focus-panel.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Check, RefreshCw, Target } from "lucide-react";
+import { useDailyFocus } from "./use-daily-focus";
+
+export function FocusPanel() {
+  const { focusTasks, totalPoints, summary, loading, accepted, accept, refresh, markDone } =
+    useDailyFocus();
+
+  if (loading) {
+    return (
+      <section className="border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex items-center gap-2 text-slate-500">
+          <RefreshCw size={16} className="animate-spin" />
+          <span className="text-sm">読み込み中...</span>
+        </div>
+      </section>
+    );
+  }
+
+  if (focusTasks.length === 0) {
+    return (
+      <section className="border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex items-center gap-2 text-slate-500">
+          <Target size={16} />
+          <span className="text-sm">今やるべきタスクはありません</span>
+        </div>
+        <p className="mt-2 text-xs text-slate-400">スプリントにタスクを追加してください</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="border border-slate-200 bg-gradient-to-br from-slate-50 via-white to-slate-50 p-6 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Target size={18} className="text-[#2323eb]" />
+          <h2 className="text-lg font-semibold text-slate-900">今やること</h2>
+          <span className="text-sm text-slate-500">{summary}</span>
+        </div>
+        <button
+          onClick={refresh}
+          className="flex items-center gap-1 text-xs text-slate-500 transition hover:text-slate-700"
+        >
+          <RefreshCw size={12} />
+          更新
+        </button>
+      </div>
+
+      <div className="mt-4 space-y-2">
+        {focusTasks.map(({ task, score, reasons }) => (
+          <div
+            key={task.id}
+            className="flex items-center gap-3 border border-slate-200 bg-white px-4 py-3 transition hover:border-slate-300"
+          >
+            <button
+              onClick={() => markDone(task.id)}
+              className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-slate-300 text-slate-400 transition hover:border-[#2323eb] hover:text-[#2323eb]"
+            >
+              <Check size={12} />
+            </button>
+            <div className="flex-1 min-w-0">
+              <p className="truncate text-sm font-medium text-slate-800">{task.title}</p>
+              <div className="mt-1 flex flex-wrap gap-1">
+                <span className="inline-flex items-center rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-600">
+                  {task.points}pt
+                </span>
+                {reasons.map((reason, i) => (
+                  <span
+                    key={i}
+                    className="inline-flex items-center rounded bg-[#2323eb]/10 px-1.5 py-0.5 text-[10px] text-[#2323eb]"
+                  >
+                    {reason}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {!accepted && (
+        <div className="mt-4 flex gap-2">
+          <button
+            onClick={accept}
+            className="flex-1 bg-[#2323eb] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-md hover:shadow-[#2323eb]/30"
+          >
+            これでいく
+          </button>
+          <button
+            onClick={refresh}
+            className="border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 transition hover:border-slate-300"
+          >
+            変える
+          </button>
+        </div>
+      )}
+
+      {accepted && (
+        <div className="mt-4 flex items-center gap-2 rounded bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+          <Check size={14} />
+          今日のフォーカスを決定しました
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/components/use-daily-focus.ts
+++ b/app/components/use-daily-focus.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  type DailyFocusResult,
+  type FocusTask,
+  getFocusSummary,
+  selectDailyFocus,
+} from "../../lib/daily-focus";
+import { TASK_STATUS, type TaskDTO } from "../../lib/types";
+import { useWorkspaceId } from "./use-workspace-id";
+
+export type UseDailyFocusOptions = {
+  maxTasks?: number;
+  maxPoints?: number;
+  includeBacklog?: boolean;
+};
+
+export function useDailyFocus(options: UseDailyFocusOptions = {}) {
+  const { maxTasks = 3, maxPoints = 8, includeBacklog = false } = options;
+  const { workspaceId, ready } = useWorkspaceId();
+
+  const [tasks, setTasks] = useState<TaskDTO[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [accepted, setAccepted] = useState(false);
+
+  const fetchTasks = useCallback(async () => {
+    if (!ready || !workspaceId) {
+      setTasks([]);
+      return;
+    }
+    setLoading(true);
+    try {
+      const statuses = includeBacklog
+        ? `status=${TASK_STATUS.SPRINT}&status=${TASK_STATUS.BACKLOG}`
+        : `status=${TASK_STATUS.SPRINT}`;
+      const res = await fetch(`/api/tasks?${statuses}&limit=100`);
+      if (!res.ok) {
+        setTasks([]);
+        return;
+      }
+      const data = await res.json();
+      setTasks(data.tasks ?? []);
+    } finally {
+      setLoading(false);
+    }
+  }, [ready, workspaceId, includeBacklog]);
+
+  useEffect(() => {
+    void fetchTasks();
+  }, [fetchTasks]);
+
+  const result: DailyFocusResult = useMemo(() => {
+    return selectDailyFocus(tasks, { maxTasks, maxPoints, includeBacklog });
+  }, [tasks, maxTasks, maxPoints, includeBacklog]);
+
+  const summary = useMemo(() => getFocusSummary(result), [result]);
+
+  const accept = useCallback(() => {
+    setAccepted(true);
+  }, []);
+
+  const refresh = useCallback(() => {
+    setAccepted(false);
+    void fetchTasks();
+  }, [fetchTasks]);
+
+  const markDone = useCallback(
+    async (taskId: string) => {
+      const res = await fetch(`/api/tasks/${taskId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: TASK_STATUS.DONE }),
+      });
+      if (res.ok) {
+        void fetchTasks();
+      }
+    },
+    [fetchTasks],
+  );
+
+  return {
+    // State
+    focusTasks: result.focusTasks,
+    skippedTasks: result.skippedTasks,
+    totalPoints: result.totalPoints,
+    summary,
+    loading,
+    accepted,
+    // Actions
+    accept,
+    refresh,
+    markDone,
+  };
+}

--- a/lib/daily-focus.ts
+++ b/lib/daily-focus.ts
@@ -1,0 +1,176 @@
+import { SEVERITY, type Severity, TASK_STATUS, type TaskDTO } from "./types";
+
+/**
+ * デイリーフォーカス選択アルゴリズム
+ *
+ * 「今やるべきこと」を自動選択する
+ * - ブロックされていない
+ * - 期限が近い
+ * - 緊急度が高い
+ * - 小さいタスクで着手しやすい
+ */
+
+const URGENCY_WEIGHT: Record<Severity, number> = {
+  [SEVERITY.HIGH]: 3,
+  [SEVERITY.MEDIUM]: 2,
+  [SEVERITY.LOW]: 1,
+};
+
+export type FocusTask = {
+  task: TaskDTO;
+  score: number;
+  reasons: string[];
+};
+
+export type DailyFocusResult = {
+  focusTasks: FocusTask[];
+  skippedTasks: { task: TaskDTO; reason: string }[];
+  totalPoints: number;
+};
+
+/**
+ * タスクがブロックされているかチェック
+ */
+function isBlocked(task: TaskDTO): boolean {
+  return (task.dependencies ?? []).some((dep) => dep.status !== TASK_STATUS.DONE);
+}
+
+/**
+ * 期限までの日数を計算（期限なしはInfinity）
+ */
+function daysUntilDue(task: TaskDTO): number {
+  if (!task.dueDate) return Infinity;
+  const due = new Date(task.dueDate);
+  const now = new Date();
+  const diffMs = due.getTime() - now.getTime();
+  return Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * フォーカススコアを計算
+ *
+ * 高いほど優先:
+ * - 期限が近い → スコア高
+ * - 緊急度が高い → スコア高
+ * - ポイントが小さい → スコア高（着手しやすい）
+ */
+export function calculateFocusScore(task: TaskDTO): { score: number; reasons: string[] } {
+  const reasons: string[] = [];
+  let score = 0;
+
+  // 期限スコア (0-50点)
+  const days = daysUntilDue(task);
+  if (days <= 0) {
+    score += 50;
+    reasons.push("期限超過");
+  } else if (days <= 1) {
+    score += 40;
+    reasons.push("今日が期限");
+  } else if (days <= 3) {
+    score += 30;
+    reasons.push("期限が近い");
+  } else if (days <= 7) {
+    score += 15;
+  } else if (days !== Infinity) {
+    score += 5;
+  }
+
+  // 緊急度スコア (0-30点)
+  const urgencyScore = URGENCY_WEIGHT[task.urgency] * 10;
+  score += urgencyScore;
+  if (task.urgency === SEVERITY.HIGH) {
+    reasons.push("緊急度:高");
+  }
+
+  // サイズスコア (0-20点) - 小さいほど高い
+  // 1pt=20, 2pt=18, 3pt=15, 5pt=10, 8pt=5, 13+=0
+  const sizeScore = Math.max(0, 20 - task.points * 2);
+  score += sizeScore;
+  if (task.points <= 2) {
+    reasons.push("すぐ終わる");
+  }
+
+  return { score, reasons };
+}
+
+/**
+ * 今日のフォーカスタスクを選択
+ */
+export function selectDailyFocus(
+  tasks: TaskDTO[],
+  options: {
+    maxTasks?: number;
+    maxPoints?: number;
+    includeBacklog?: boolean;
+  } = {},
+): DailyFocusResult {
+  const { maxTasks = 3, maxPoints = 8, includeBacklog = false } = options;
+
+  const candidates: TaskDTO[] = [];
+  const skippedTasks: { task: TaskDTO; reason: string }[] = [];
+
+  // フィルタリング
+  for (const task of tasks) {
+    // 完了済みはスキップ
+    if (task.status === TASK_STATUS.DONE) {
+      continue;
+    }
+
+    // バックログはオプションで含める
+    if (task.status === TASK_STATUS.BACKLOG && !includeBacklog) {
+      continue;
+    }
+
+    // SPRINTまたはBACKLOG（オプション時）のみ
+    if (task.status !== TASK_STATUS.SPRINT && task.status !== TASK_STATUS.BACKLOG) {
+      continue;
+    }
+
+    // ブロックされている
+    if (isBlocked(task)) {
+      skippedTasks.push({ task, reason: "依存タスクが未完了" });
+      continue;
+    }
+
+    candidates.push(task);
+  }
+
+  // スコア計算してソート
+  const scored = candidates.map((task) => {
+    const { score, reasons } = calculateFocusScore(task);
+    return { task, score, reasons };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+
+  // 上位を選択（ポイント上限も考慮）
+  const selected: FocusTask[] = [];
+  let totalPoints = 0;
+
+  for (const item of scored) {
+    if (selected.length >= maxTasks) break;
+    if (totalPoints + item.task.points > maxPoints) {
+      // ポイントオーバーでもmaxTasksに達してなければ小さいのを探す
+      continue;
+    }
+    selected.push(item);
+    totalPoints += item.task.points;
+  }
+
+  return {
+    focusTasks: selected,
+    skippedTasks,
+    totalPoints,
+  };
+}
+
+/**
+ * フォーカス結果のサマリーを生成
+ */
+export function getFocusSummary(result: DailyFocusResult): string {
+  const { focusTasks, totalPoints } = result;
+  if (focusTasks.length === 0) {
+    return "今やるべきタスクはありません";
+  }
+  return `${focusTasks.length}件 / ${totalPoints}pt`;
+}


### PR DESCRIPTION
## Summary
- アプリを開くたびに「今やること」を自動選択する機能を追加
- 期限・緊急度・タスクサイズに基づいてスコアリング
- ユーザーは「これでいく」or「変える」で決定（委任モデル）

## 変更内容
- `lib/daily-focus.ts`: フォーカス選択アルゴリズム（クライアントサイド計算）
- `app/components/use-daily-focus.ts`: React hook
- `app/components/focus-panel.tsx`: UIコンポーネント
- `app/backlog/page.tsx`: FocusPanelを統合

## スコアリングロジック
- 期限スコア (0-50pt): 期限超過→50, 今日→40, 3日以内→30
- 緊急度スコア (0-30pt): HIGH→30, MEDIUM→20, LOW→10
- サイズスコア (0-20pt): 小さいタスクほど高い（着手しやすい）

## Test plan
- [ ] バックログページを開いて「今やること」パネルが表示される
- [ ] スプリントにタスクがあればフォーカスタスクが選択される
- [ ] 「これでいく」で決定、「変える」で再選択
- [ ] タスクのチェックで完了マーク

🤖 Generated with [Claude Code](https://claude.com/claude-code)