### PR TITLE
chore: migrate console.* to structured logger

### DIFF
--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -5,6 +5,7 @@ import { ok } from "../../../../lib/api-response";
 import { AuthRegisterSchema } from "../../../../lib/contracts/auth";
 import { createDomainErrors } from "../../../../lib/http/errors";
 import { parseBody } from "../../../../lib/http/validation";
+import { logger } from "../../../../lib/logger";
 import { sendEmail } from "../../../../lib/mailer";
 import prisma from "../../../../lib/prisma";
 
@@ -66,7 +67,7 @@ export async function POST(request: Request) {
             html: `<p>以下のリンクからメール認証を完了してください。</p><p><a href="${verifyUrl}">${verifyUrl}</a></p>`,
           });
         } catch (mailError) {
-          console.error("Email verification send failed", mailError);
+          logger.error("Email verification send failed", {}, mailError);
         }
       }
 

--- a/app/api/memory/questions/[id]/route.ts
+++ b/app/api/memory/questions/[id]/route.ts
@@ -5,6 +5,7 @@ import { ok } from "../../../../../lib/api-response";
 import { MemoryQuestionActionSchema } from "../../../../../lib/contracts/memory";
 import { createDomainErrors } from "../../../../../lib/http/errors";
 import { parseBody } from "../../../../../lib/http/validation";
+import { logger } from "../../../../../lib/logger";
 import prisma from "../../../../../lib/prisma";
 
 const pickClaimValue = (question: {
@@ -13,7 +14,7 @@ const pickClaimValue = (question: {
   valueBool: boolean | null;
   valueJson: unknown | null;
 }) => {
-  console.info("MEMORY_QUESTION_ACCEPT values", {
+  logger.debug("MEMORY_QUESTION_ACCEPT values", {
     valueJsonType: typeof question.valueJson,
     valueJsonNull: question.valueJson === null,
   });

--- a/app/api/memory/questions/route.ts
+++ b/app/api/memory/questions/route.ts
@@ -5,6 +5,7 @@ import { ok } from "../../../../lib/api-response";
 import { MemoryQuestionCreateSchema } from "../../../../lib/contracts/memory";
 import { createDomainErrors } from "../../../../lib/http/errors";
 import { parseBody } from "../../../../lib/http/validation";
+import { logger } from "../../../../lib/logger";
 import prisma from "../../../../lib/prisma";
 
 const CONFIDENCE_THRESHOLD = 0.7;
@@ -77,7 +78,7 @@ export async function POST(request: Request) {
       const body = await parseBody(request, MemoryQuestionCreateSchema, {
         code: "MEMORY_VALIDATION",
       });
-      console.info("MEMORY_QUESTION_CREATE input", {
+      logger.debug("MEMORY_QUESTION_CREATE input", {
         typeId: body.typeId,
         valueJsonType: typeof body.valueJson,
         valueJsonNull: body.valueJson === null,
@@ -88,7 +89,7 @@ export async function POST(request: Request) {
       const valueNum = body.valueNum ?? null;
       const valueBool = body.valueBool ?? null;
       const valueJson = body.valueJson ?? null;
-      console.info("MEMORY_QUESTION_CREATE normalized", {
+      logger.debug("MEMORY_QUESTION_CREATE normalized", {
         valueJsonType: typeof valueJson,
         valueJsonNull: valueJson === null,
       });

--- a/app/api/memory/route.ts
+++ b/app/api/memory/route.ts
@@ -11,6 +11,7 @@ import { ok } from "../../../lib/api-response";
 import { MemoryClaimCreateSchema, MemoryClaimDeleteSchema } from "../../../lib/contracts/memory";
 import { createDomainErrors } from "../../../lib/http/errors";
 import { parseBody } from "../../../lib/http/validation";
+import { logger } from "../../../lib/logger";
 import prisma from "../../../lib/prisma";
 
 const errors = createDomainErrors("MEMORY");
@@ -225,7 +226,7 @@ export async function POST(request: Request) {
       const body = await parseBody(request, MemoryClaimCreateSchema, {
         code: "MEMORY_VALIDATION",
       });
-      console.info("MEMORY_CLAIM_CREATE input", {
+      logger.debug("MEMORY_CLAIM_CREATE input", {
         typeId: body.typeId,
         valueType: typeof body.value,
         valueNull: body.value === null,
@@ -248,7 +249,7 @@ export async function POST(request: Request) {
       }
 
       const parsed = parseValue(rawValue, type.valueType);
-      console.info("MEMORY_CLAIM_CREATE parsed", {
+      logger.debug("MEMORY_CLAIM_CREATE parsed", {
         ok: parsed.ok,
         valueType: type.valueType,
       });

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -8,6 +8,7 @@ import { applyAutomationForTask } from "../../../../lib/automation";
 import { TaskUpdateSchema } from "../../../../lib/contracts/task";
 import { createDomainErrors } from "../../../../lib/http/errors";
 import { parseBody } from "../../../../lib/http/validation";
+import { logger } from "../../../../lib/logger";
 import { badPoints } from "../../../../lib/points";
 import prisma from "../../../../lib/prisma";
 import {
@@ -95,7 +96,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
       const body = await parseBody(request, TaskUpdateSchema, {
         code: "TASK_VALIDATION",
       });
-      console.info("TASK_UPDATE input", {
+      logger.debug("TASK_UPDATE input", {
         id,
         status: body.status,
         type: body.type,
@@ -136,7 +137,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
         data.tags = Array.isArray(body.tags) ? body.tags.map((tag: string) => String(tag)) : [];
       }
       const statusValue = body.status && isTaskStatus(body.status) ? body.status : null;
-      console.info("TASK_UPDATE narrowed", {
+      logger.debug("TASK_UPDATE narrowed", {
         statusValue,
         typeValue: data.type ?? null,
       });

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -9,6 +9,7 @@ import { applyAutomationForTask } from "../../../lib/automation";
 import { TaskCreateSchema } from "../../../lib/contracts/task";
 import { createDomainErrors } from "../../../lib/http/errors";
 import { parseBody } from "../../../lib/http/validation";
+import { logger } from "../../../lib/logger";
 import { mapTaskWithDependencies } from "../../../lib/mappers/task";
 import { badPoints } from "../../../lib/points";
 import prisma from "../../../lib/prisma";
@@ -171,7 +172,7 @@ export async function POST(request: Request) {
       const body = await parseBody(request, TaskCreateSchema, {
         code: "TASK_VALIDATION",
       });
-      console.info("TASK_CREATE input", {
+      logger.debug("TASK_CREATE input", {
         status: body.status,
         type: body.type,
         checklistType: Array.isArray(body.checklist) ? "array" : typeof body.checklist,
@@ -219,7 +220,7 @@ export async function POST(request: Request) {
         : [];
       const statusValue = isTaskStatus(status) ? status : TASK_STATUS.BACKLOG;
       const typeValue = isTaskType(type) ? type : TASK_TYPE.PBI;
-      console.info("TASK_CREATE narrowed", {
+      logger.debug("TASK_CREATE narrowed", {
         statusValue,
         typeValue,
       });

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,41 @@
+/**
+ * Next.js Instrumentation
+ *
+ * This file runs once when the Next.js server starts.
+ * Used for setting up global error handlers and monitoring.
+ *
+ * @see https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
+ */
+
+export async function register() {
+  // Only run on server
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { logger } = await import("./lib/logger");
+
+    // Handle unhandled promise rejections
+    process.on("unhandledRejection", (reason, _promise) => {
+      logger.error(
+        "Unhandled Promise Rejection",
+        {
+          type: "unhandledRejection",
+        },
+        reason,
+      );
+    });
+
+    // Handle uncaught exceptions
+    process.on("uncaughtException", (error) => {
+      logger.error(
+        "Uncaught Exception",
+        {
+          type: "uncaughtException",
+        },
+        error,
+      );
+      // Let the process crash after logging
+      process.exit(1);
+    });
+
+    logger.info("Server instrumentation initialized");
+  }
+}

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -1,5 +1,6 @@
 import { type AiUsageContext, recordAiUsage } from "./ai-usage";
 import { safeDecrypt } from "./encryption";
+import { logger } from "./logger";
 import prisma from "./prisma";
 
 export type AiProviderConfig = {
@@ -88,7 +89,7 @@ export async function resolveAiProvider(): Promise<AiProviderConfig | null> {
     // Decrypt API key if encrypted, otherwise use as-is (legacy or env)
     const decryptedApiKey = safeDecrypt(setting.apiKey);
     if (!decryptedApiKey) {
-      console.error("Failed to decrypt AI API key");
+      logger.error("Failed to decrypt AI API key");
       return null;
     }
     return {

--- a/lib/encryption.ts
+++ b/lib/encryption.ts
@@ -1,4 +1,5 @@
 import crypto from "crypto";
+import { logger } from "./logger";
 
 /**
  * AES-256-GCM encryption utilities for sensitive data
@@ -113,8 +114,8 @@ export function safeDecrypt(value: string | null | undefined): string | null {
 
   try {
     return decrypt(value);
-  } catch {
-    console.error("Failed to decrypt value");
+  } catch (error) {
+    logger.error("Failed to decrypt value", {}, error);
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- サーバーサイドの`console.*`を構造化ログに移行
- グローバルエラーハンドラを追加

## Changes

### ログ移行
以下のファイルで`console.info/error`を`logger.debug/error`に置換:
- `lib/encryption.ts`
- `lib/ai-provider.ts`
- `app/api/memory/route.ts`
- `app/api/memory/questions/route.ts`
- `app/api/memory/questions/[id]/route.ts`
- `app/api/auth/register/route.ts`
- `app/api/tasks/route.ts`
- `app/api/tasks/[id]/route.ts`

### グローバルエラーハンドラ (`instrumentation.ts`)
- `unhandledRejection` - 未処理のPromise拒否をログ出力
- `uncaughtException` - 未処理の例外をログ出力後に終了

### 移行しなかったファイル（意図的）
- `lib/logger.ts` - ログ出力そのもの
- `lib/env.ts` - 起動時バリデーション（ログ初期化前）
- `lib/ai-reaction-tracker.ts` - クライアントサイドコード

## Test plan
- [ ] APIエラー時にJSON形式でログが出力されることを確認
- [ ] `npm run dev`起動時に"Server instrumentation initialized"が出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)