### PR TITLE
fix: exclude mcp-server from Next.js TypeScript build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "mcp-server"]
 }


### PR DESCRIPTION
The mcp-server directory was being included in the Next.js build process, causing module resolution errors for @modelcontextprotocol/sdk. Adding it to tsconfig.json exclude resolves the CD pipeline failure.