### PR TITLE
fix(mcp): copy mcp-server node_modules in Dockerfile

### DIFF
--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -44,6 +44,7 @@ RUN useradd --system --uid 1001 --gid nodejs mcp
 
 # Copy built application
 COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/mcp-server/node_modules ./mcp-server/node_modules
 COPY --from=builder /app/mcp-server/dist ./mcp-server/dist
 COPY --from=builder /app/mcp-server/package.json ./mcp-server/
 


### PR DESCRIPTION
## Summary
- mcp-serverの依存関係がrunnerステージにコピーされていなかった問題を修正

## Test plan
- CDパイプラインでMCPサーバーが正常に起動することを確認